### PR TITLE
feat: update to work with single fetch responseStub

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -13,3 +13,8 @@ export const flashSessionValuesSchema = z.object({
 export type ToastMessage = z.infer<typeof toastMessageSchema>;
 
 export type FlashSessionValues = z.infer<typeof flashSessionValuesSchema>;
+
+export type ResponseStub = {
+  readonly headers: Headers,
+  status: number
+};


### PR DESCRIPTION
# Description

This PR is a POC (not expected to be merged). With the arrival of single-fetch in remix, I wanted to see this great project reflect the changes required.

It still may requires additional props like `customStatus`, etc.

Fixes #17

If this is a new feature please add a description of what was added and why below:

- Replace `ResponseInit` param with `ResponseStub` in all functions.
- Use ResponseStub to set cookie headers
- Either throw response for redirects or return bare object for json data.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules