### PR TITLE
Update git organizations to forge-42

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Remix Toast
-![GitHub Repo stars](https://img.shields.io/github/stars/Code-Forge-Net/remix-toast?style=social)
+![GitHub Repo stars](https://img.shields.io/github/stars/forge-42/remix-toast?style=social)
 ![npm](https://img.shields.io/npm/v/remix-toast?style=plastic)
-![GitHub](https://img.shields.io/github/license/Code-Forge-Net/remix-toast?style=plastic)
+![GitHub](https://img.shields.io/github/license/forge-42/remix-toast?style=plastic)
 ![npm](https://img.shields.io/npm/dy/remix-toast?style=plastic) 
 ![npm](https://img.shields.io/npm/dw/remix-toast?style=plastic) 
-![GitHub top language](https://img.shields.io/github/languages/top/Code-Forge-Net/remix-toast?style=plastic) 
+![GitHub top language](https://img.shields.io/github/languages/top/forge-42/remix-toast?style=plastic)
 
 Simple server-side toast management library for React router v7 / Remix.run!
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/forge42dev/remix-toast.git"
+    "url": "git+https://github.com/forge-42/remix-toast.git"
   },
   "keywords": [
     "Remix",
@@ -63,10 +63,10 @@
   "author": "Alem Tuzlak",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/forge42dev/remix-toast/issues"
+    "url": "https://github.com/forge-42/remix-toast/issues"
   },
-  "homepage": "https://github.com/forge42dev/remix-toast#readme",
-  "readme": "https://github.com/forge42dev/remix-toast#readme",
+  "homepage": "https://github.com/forge-42/remix-toast#readme",
+  "readme": "https://github.com/forge-42/remix-toast#readme",
   "dependencies": {
     "zod": "^3.22.3"
   },


### PR DESCRIPTION
# Description

This patch changes a few git links to the `forge-42` organization.

Fixes # (issue)

N/A.

## Type of change

Please delete options that are not relevant.

- [x] Minor fix unrelated to the code.

# How Has This Been Tested?

N/A

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings or errors
