### PR TITLE
support toasts on thrown responses

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -19,7 +19,14 @@ export function unstable_toastMiddleware(props?: { customSession?: SessionStorag
 
     context.set(toastContext, toast ?? null);
     // Call the next middleware or route handler
-    const res = await next();
+    const res = await next().catch((err: unknown) => {
+      // if the error is a response, continue to apply the toast middleware
+      if (err instanceof Response) {
+        return err;
+      }
+      // otherwise let the error bubble up
+      throw err;
+    });
 
     if (res instanceof Response && toast) {
       res.headers.append("Set-Cookie", headers.get("Set-Cookie") ?? "");


### PR DESCRIPTION
# Description

Our auth middleware throws a standard rrv7 redirect response and I noticed that middleware toasts weren't working with that. The toast middleware is on the root loader, and the auth middleware is on a subpath (but in my testing it didn't matter if I moved both to the root, the toast still wouldn't show up).

```typescript

// root.tsx
export const unstable_middleware = [toastMiddleware()];

// routes/app.route.tsx
export const unstable_middleware = [authMiddleware];

const authMiddleware: unstable_MiddlewareFunction = async ({ request, context }) => {
    try {
        const session = await getCurrentSession(request);
        context.set(sessionContext, session);
    } catch (e) {
		// this toast doesn't work...
        setToast(context, {
            message: "You need to sign in",
            type: 'error',
        });        
        throw redirect('/login');
    }
};
```


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has only been tested manually. And I don't know all the edge cases to know what else to test. I didn't see any unit tests already, so I couldn't easily add any. 

I had one big question which I'll comment on directly in the code.

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules