### PR TITLE
Stabilized middleware API for RR v7.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ export const action = () => {
 In order to be able to show toasts anywhere in the app you need to add the following code to your `root.tsx` file.
 
 ```tsx
-import { getToast, setToast, unstable_toastMiddleware } from "remix-toast/middleware";
+import { getToast, setToast, toastMiddleware } from "remix-toast/middleware";
 
 export const loader = async ({ request, context }: Route.LoaderArgs) => {
   // Extracts the toast from the request
@@ -82,7 +82,7 @@ export default function App({ loaderData }: Route.ComponentArgs) {
 }
 
 // Export the middleware to be used in the app
-export const unstable_middleware = [unstable_toastMiddleware()];
+export const middleware = [toastMiddleware()];
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "format-code": "npm run prettier:fix & npm run lint:fix"
   },
   "peerDependencies": {
-    "react-router": ">=7.8.0"
+    "react-router": ">=7.9.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-toast",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Utility functions for server-side toast notifications",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,17 +1,12 @@
-import {
-  type SessionStorage,
-  type unstable_MiddlewareFunction,
-  type unstable_RouterContextProvider,
-  unstable_createContext,
-} from "react-router";
+import { type SessionStorage, type MiddlewareFunction, type RouterContextProvider, createContext } from "react-router";
 import { type ToastMessage, getToast as getToastPrimitive } from "..";
 import { FLASH_SESSION } from "../schema";
 import { sessionStorage } from "../session";
 
-const toastContext = unstable_createContext<ToastMessage | null>(null);
-const sessionToastContext = unstable_createContext<ToastMessage | null>(null);
+const toastContext = createContext<ToastMessage | null>(null);
+const sessionToastContext = createContext<ToastMessage | null>(null);
 
-export function unstable_toastMiddleware(props?: { customSession?: SessionStorage }): unstable_MiddlewareFunction {
+export function toastMiddleware(props?: { customSession?: SessionStorage }): MiddlewareFunction {
   const { customSession } = props || {};
   const sessionToUse = customSession || sessionStorage;
   return async function toastMiddleware({ request, context }, next) {
@@ -37,11 +32,16 @@ export function unstable_toastMiddleware(props?: { customSession?: SessionStorag
 }
 
 export const setToast = (
-  context: unstable_RouterContextProvider | Readonly<unstable_RouterContextProvider>,
+  context: RouterContextProvider | Readonly<RouterContextProvider>,
   toast: ToastMessage | null,
 ) => {
   context.set(sessionToastContext, toast);
 };
 
-export const getToast = (context: unstable_RouterContextProvider | Readonly<unstable_RouterContextProvider>) =>
+export const getToast = (context: RouterContextProvider | Readonly<RouterContextProvider>) =>
   context.get(toastContext);
+
+/**
+ * @deprecated Use `toastMiddleware` instead.
+ */
+export const unstable_toastMiddleware = toastMiddleware;

--- a/test-apps/react-router/app/root.tsx
+++ b/test-apps/react-router/app/root.tsx
@@ -3,7 +3,7 @@ import { type LinksFunction, type LoaderFunctionArgs, data } from "react-router"
 import { Links, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData } from "react-router";
 import { ToastContainer, toast as notify } from "react-toastify";
 import toastStyles from "react-toastify/ReactToastify.css?url";
-import { getToast, unstable_toastMiddleware } from "remix-toast/middleware";
+import { getToast, toastMiddleware } from "remix-toast/middleware";
 
 export const links: LinksFunction = () => [{ rel: "stylesheet", href: toastStyles }];
 
@@ -39,4 +39,4 @@ export default function App() {
   );
 }
 
-export const unstable_middleware = [unstable_toastMiddleware()];
+export const middleware = [toastMiddleware()];

--- a/test-apps/react-router/react-router.config.ts
+++ b/test-apps/react-router/react-router.config.ts
@@ -2,12 +2,12 @@ import type { Config } from "@react-router/dev/config";
 
 declare module "react-router" {
   interface Future {
-    unstable_middleware: true; // 👈 Enable middleware types
+    v8_middleware: true; // 👈 Enable middleware types
   }
 }
 
 export default {
   future: {
-    unstable_middleware: true, // 👈 Enable middleware
+    v8_middleware: true, // 👈 Enable middleware
   },
 } satisfies Config;


### PR DESCRIPTION
# Description

- Switch library and example app to the stable React Router middleware/context APIs introduced in 7.9.0
- Keep `unstable_toastMiddleware` as a deprecated alias and bump the peer dependency to react-router@>=7.9.0
- Refresh README instructions to show the new `toastMiddleware` export and config flag updates

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] npm run build

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules